### PR TITLE
Add `http_options` to Vault client

### DIFF
--- a/lib/vault.ex
+++ b/lib/vault.ex
@@ -156,6 +156,7 @@ defmodule Vault do
             engine: Vault.Engine.Generic,
             token: nil,
             token_expires_at: nil,
+            http_options: [],
             credentials: %{}
 
   @type options :: map() | Keyword.t()
@@ -221,6 +222,7 @@ defmodule Vault do
   * `:engine` Module for your Secret Engine adapter. Defaults to `Vault.Engine.Generic`.
   * `:host` - host of your vault instance. Should contain the port, if needed. Should not contain a trailing slash. Defaults to `System.get_env("VAULT_ADDR")`.
   * `:http` - Module for your http adapter. Defaults to `Vault.HTTP.Tesla` when `:tesla` is present.
+  * `:http_options` - A keyword list of options to your HTTP adapter.
   * `:token` - A vault token.
   * `:token_expires_at` A `NaiveDateTime` instance that represents when the token expires, in utc.
   * `:credentials` - The credentials to use when authenticating with your Auth adapter.

--- a/lib/vault/http/adapter.ex
+++ b/lib/vault/http/adapter.ex
@@ -10,6 +10,7 @@ defmodule Vault.HTTP.Adapter do
   @type url :: String.t()
   @type params :: map()
   @type headers :: list({String.t(), String.t()})
+  @type http_options :: Keyword.t()
 
   @type response :: %{
           headers: list,
@@ -17,5 +18,5 @@ defmodule Vault.HTTP.Adapter do
           body: String.t()
         }
 
-  @callback request(method, url, params, headers) :: {:ok, response} | {:error, term}
+  @callback request(method, url, params, headers, http_options) :: {:ok, response} | {:error, term}
 end

--- a/lib/vault/http/http.ex
+++ b/lib/vault/http/http.ex
@@ -52,7 +52,12 @@ defmodule Vault.HTTP do
   @doc """
   Make an arbitrary request against the configured vault instance. See options above for configuration.
   """
-  def request(%Vault{http: http, host: host, json: json, token: token}, method, path, options) do
+  def request(
+        %Vault{http: http, host: host, json: json, token: token, http_options: http_options},
+        method,
+        path,
+        options
+      ) do
     body = Keyword.get(options, :body, %{})
     query_params = Keyword.get(options, :query_params, %{}) |> URI.encode_query()
     headers = Keyword.get(options, :headers, [])
@@ -62,7 +67,7 @@ defmodule Vault.HTTP do
     url = "#{host}/#{version}/#{path}?#{query_params}" |> String.trim_trailing("?")
 
     with {:ok, encoded} <- encode(json, body),
-         {:ok, %{body: body}} <- http.request(method, url, encoded, headers),
+         {:ok, %{body: body}} <- http.request(method, url, encoded, headers, http_options),
          {:ok, decoded} <- decode(json, body) do
       {:ok, decoded}
     else

--- a/lib/vault/http/tesla.ex
+++ b/lib/vault/http/tesla.ex
@@ -22,26 +22,57 @@ if Code.ensure_loaded?(Tesla) do
     following to your mix config:
 
       config :tesla,
-          adapter: Tesla.Adapters.Hackney 
+          adapter: Tesla.Adapters.Hackney
           # or adapter: Tesla.Adapters.IBrowse
 
-    You can also use `httpc`, but be aware that there's some strange behavior 
-    around httpc redirects at this time. 
+    You can also use `httpc`, but be aware that there's some strange behavior
+    around httpc redirects at this time.
+
+    ### Passing HTTP options
+    You may want to configure and pass HTTP options to the adapter you choose.
+    In this case, you can pass the `http_options` right to the `Vault` client, like:
+
+      Vault.new([
+        engine: Vault.Engine.KVV2,
+        http_options: [
+          adapter: {Tesla.Adapter.Hackney, ssl_options: [cacertfile: "/path/to/file"]},
+          middleware: [
+            {Tesla.Middleware.Retry, delay: 500, max_retries: 10},
+            {Tesla.Middleware.Logger, log_level: :debug},
+            {Tesla.Middleware.FollowRedirects, max_redirects: 3}
+          ]
+        ]
+      ])
+
     """
     use Tesla
 
     @behaviour Vault.HTTP.Adapter
 
-    defp client() do
-      Tesla.client([
-        {Tesla.Middleware.FollowRedirects, []}
-      ])
+    @impl true
+    def request(method, url, params, headers, http_options) do
+      params = if params == "{}" and method in [:get, :delete, :head], do: nil, else: params
+
+      Tesla.request(client(http_options), method: method, url: url, headers: headers, body: params)
     end
 
-    @impl true
-    def request(method, url, params, headers) do
-      params = if params == "{}" and method in [:get, :delete, :head], do: nil, else: params
-      Tesla.request(client(), method: method, url: url, headers: headers, body: params)
+    defp client(http_options) do
+      middlewares =
+        Keyword.get(
+          http_options,
+          :middleware,
+          [
+            {Tesla.Middleware.FollowRedirects, []}
+          ]
+        )
+
+      case Keyword.fetch(http_options, :adapter) do
+        {:ok, adapter} ->
+          Tesla.client(middlewares, adapter)
+
+        :error ->
+          Tesla.client(middlewares)
+      end
     end
   end
 end

--- a/test/support/test_http.ex
+++ b/test/support/test_http.ex
@@ -10,18 +10,31 @@ defmodule Vault.Http.Test do
         :post,
         "http://localhost/v1/auth/approle/login",
         ~s<{"role_id":"error","secret_id":"secret_id"}>,
-        _headers
+        _headers,
+        _http_options
       ) do
     {:error, "Adapter Error"}
   end
 
-  def request(:post, "http://localhost/v1/auth/github/login", ~s<{"token":"error"}>, _headers) do
+  def request(
+        :post,
+        "http://localhost/v1/auth/github/login",
+        ~s<{"token":"error"}>,
+        _headers,
+        _http_options
+      ) do
     {:error, "Adapter Error"}
   end
 
-  def request(:get, "http://localhost/v1/auth/token/lookup-self", _, [
-        {"X-Vault-Token", "error"} | _rest
-      ]) do
+  def request(
+        :get,
+        "http://localhost/v1/auth/token/lookup-self",
+        _,
+        [
+          {"X-Vault-Token", "error"} | _rest
+        ],
+        _http_options
+      ) do
     {:error, "Adapter Error"}
   end
 
@@ -29,12 +42,19 @@ defmodule Vault.Http.Test do
         :post,
         "http://localhost/v1/auth/ldap/" <> _rest,
         ~s<{"password":"error"}>,
-        _headers
+        _headers,
+        _http_options
       ) do
     {:error, "Adapter Error"}
   end
 
-  def request(:post, "http://localhost/v1/auth/userpass/" <> _rest, ~s<{"password":"error"}>, _) do
+  def request(
+        :post,
+        "http://localhost/v1/auth/userpass/" <> _rest,
+        ~s<{"password":"error"}>,
+        _headers,
+        _http_options
+      ) do
     {:error, "Adapter Error"}
   end
 
@@ -42,7 +62,8 @@ defmodule Vault.Http.Test do
         :post,
         "http://localhost/v1/auth/azure/login" <> _rest,
         ~s<{"jwt":"error","role":"error"}>,
-        _
+        _headers,
+        _http_options
       ) do
     {:error, "Adapter Error"}
   end
@@ -51,7 +72,8 @@ defmodule Vault.Http.Test do
         :post,
         "http://localhost/v1/auth/gcp/login" <> _rest,
         ~s<{"jwt":"error","role":"error"}>,
-        _
+        _headers,
+        _http_options
       ) do
     {:error, "Adapter Error"}
   end
@@ -60,7 +82,8 @@ defmodule Vault.Http.Test do
         :post,
         "http://localhost/v1/auth/jwt/login" <> _rest,
         ~s<{"jwt":"error","role":"error"}>,
-        _
+        _headers,
+        _http_options
       ) do
     {:error, "Adapter Error"}
   end
@@ -69,13 +92,22 @@ defmodule Vault.Http.Test do
         :post,
         "http://localhost/v1/auth/kubernetes/login" <> _rest,
         ~s<{"jwt":"error","role":"error"}>,
-        _
+        _headers,
+        _http_options
       ) do
     {:error, "Adapter Error"}
   end
 
-  def request(method, path, body, headers) do
-    resp = Jason.encode!(%{method: method, path: path, body: body, headers: Map.new(headers)})
+  def request(method, path, body, headers, http_options) do
+    resp =
+      Jason.encode!(%{
+        method: method,
+        path: path,
+        body: body,
+        headers: Map.new(headers),
+        http_options: Map.new(http_options)
+      })
+
     {:ok, %{body: resp}}
   end
 end

--- a/test/vault_test.exs
+++ b/test/vault_test.exs
@@ -187,7 +187,8 @@ defmodule VaultTest do
               "method" => "get",
               "headers" => %{"X-Vault-Token" => "token"},
               "path" => "http://localhost/v1/path/to/call",
-              "body" => "{}"
+              "body" => "{}",
+              "http_options" => %{}
             }} == Vault.request(vault, :get, "path/to/call", [])
   end
 
@@ -200,7 +201,8 @@ defmodule VaultTest do
               "method" => "get",
               "headers" => %{"X-Vault-Token" => "token", "X-Forwarded-For" => "http://localhost"},
               "path" => "http://localhost/v1/path/to/call",
-              "body" => "{}"
+              "body" => "{}",
+              "http_options" => %{}
             }} == Vault.request(vault, :get, "path/to/call", headers: headers)
   end
 
@@ -213,7 +215,8 @@ defmodule VaultTest do
               "method" => "get",
               "headers" => %{"X-Vault-Token" => "token"},
               "path" => "http://localhost/v1/path/to/call?cas=0",
-              "body" => "{}"
+              "body" => "{}",
+              "http_options" => %{}
             }} == Vault.request(vault, :get, "path/to/call", query_params: query_params)
   end
 
@@ -225,7 +228,8 @@ defmodule VaultTest do
               "method" => "get",
               "headers" => %{"X-Vault-Token" => "token"},
               "path" => "http://localhost/v3/path/to/call",
-              "body" => "{}"
+              "body" => "{}",
+              "http_options" => %{}
             }} == Vault.request(vault, :get, "path/to/call", version: "v3")
   end
 
@@ -237,7 +241,27 @@ defmodule VaultTest do
               "method" => "get",
               "headers" => %{"X-Vault-Token" => "token"},
               "path" => "http://localhost/v1/path/to/call",
-              "body" => "{\"foo\":\"bar\"}"
+              "body" => "{\"foo\":\"bar\"}",
+              "http_options" => %{}
             }} == Vault.request(vault, :get, "path/to/call", body: %{"foo" => "bar"})
+  end
+
+  test "request can use arbitrary HTTP options" do
+    vault =
+      Vault.new(
+        http: Vault.Http.Test,
+        host: "http://localhost",
+        token: "token",
+        http_options: [my_option: "foo"]
+      )
+
+    assert {:ok,
+            %{
+              "method" => "get",
+              "headers" => %{"X-Vault-Token" => "token"},
+              "path" => "http://localhost/v1/path/to/call",
+              "body" => "{}",
+              "http_options" => %{"my_option" => "foo"}
+            }} == Vault.request(vault, :get, "path/to/call")
   end
 end


### PR DESCRIPTION
This makes possible to pass arbitrary options to the HTTP client in
runtime instead of configuring the adapter globally.
So if you are using Tesla with Hackney, you can configure SSL options in
runtime:

    Vault.new(http_options: [ssl_options: [cacertfile: System.get_env("VAULT_CA_FILE")]])

This is related with https://github.com/matthewoden/libvault/issues/6.