### PR TITLE
Misc HTML doc generation changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,22 @@
 # libvault
 
-[![build status](https://travis-ci.com/matthewoden/libvault.svg?branch=master)](https://travis-ci.com/matthewoden/libvault)
+[![travis-ci.com](https://travis-ci.com/matthewoden/libvault.svg?branch=master)](https://travis-ci.com/matthewoden/libvault)
+[![hex.pm](https://img.shields.io/hexpm/v/libvault.svg)](https://hex.pm/packages/libvault)
+[![hex.pm](https://img.shields.io/hexpm/dt/libvault.svg)](https://hex.pm/packages/libvault)
+[![hex.pm](https://img.shields.io/hexpm/l/libvault.svg)](https://hex.pm/packages/libvault)
+[![github.com](https://img.shields.io/github/last-commit/matthewoden/libvault.svg)](https://github.com/matthewoden/libvault/commits/master)
 
-Highly configurable library for HashiCorp's Vault - handles authentication
-for multiple backends, and reading, writing, listing, and deleting secrets
-for a variety of engines.
+Highly configurable library for HashiCorp's
+[Vault](https://www.vaultproject.io/) which handles authentication for multiple
+backends, and reading, writing, listing, and deleting secrets for a variety of
+engines.
 
 When possible, it tries to emulate the CLI, with `read`, `write`, `list` and
-`delete` and `auth` methods. An additional `request` method is provided when you need
-further flexibility with the API.
+`delete` and `auth` methods. An additional `request` method is provided when
+you need further flexibility with the API.
+
+HTML docs can be found at
+[https://hexdocs.pm/libvault](https://hexdocs.pm/libvault).
 
 ## API Preview
 
@@ -27,10 +35,10 @@ further flexibility with the API.
 
 ## Configuration / Adapters
 
-Hashicorp's Vault is highly configurable. Rather than cover every possible option,
-this library strives to be flexible and adaptable. Auth backends, Secret
-Engines, and HTTP clients are all replaceable, and each behaviour asks for a
-minimal contract.
+Hashicorp's Vault is highly configurable. Rather than cover every possible
+option, this library strives to be flexible and adaptable. Auth backends,
+Secret Engines, and HTTP clients are all replaceable, and each behaviour asks
+for a minimal contract.
 
 ## HTTP Adapters
 
@@ -64,17 +72,18 @@ Adapters have been provided for the following auth backends:
 - [UserPass](https://www.vaultproject.io/api/auth/userpass/index.html) with `Vault.Auth.UserPass`
 - [Token](https://www.vaultproject.io/api/auth/token/index.html#lookup-a-token-self-) with `Vault.Auth.Token`
 
-In addition to the above, a generic backend is also provided (`Vault.Auth.Generic`).
-If support for auth provider is missing, you can still get up and running
-quickly, without writing a new adapter.
+In addition to the above, a generic backend is also provided
+(`Vault.Auth.Generic`).  If support for auth provider is missing, you can still
+get up and running quickly, without writing a new adapter.
 
 ## Secret Engine Adapters
 
-Most of Vault's Secret Engines use a replacable API. The `Vault.Engine.Generic`
-adapter should handle most use cases for secret fetching.
+Most of Vault's Secret Engines use a replaceable API. The
+`Vault.Engine.Generic` adapter should handle most use cases for secret
+fetching.
 
-Vault's KV version 2 broke away from the standard REST convention. So KV has been given
-its own adapter:
+Vault's KV version 2 broke away from the standard REST convention. So KV has
+been given its own adapter:
 
 - [Key/Value](https://www.vaultproject.io/api/secret/kv/index.html)
   - [v1](https://www.vaultproject.io/api/secret/kv/kv-v1.html) with `Vault.Engine.KVV1`
@@ -84,15 +93,16 @@ its own adapter:
 
 The core library only handles the basics around secret fetching. If you need to
 access additional API endpoints, this library also provides a `Vault.request`
-method. This should allow you to tap into the complete vault REST API, while still
-benefiting from token control, JSON parsing, and other HTTP client nicities.
+method. This should allow you to tap into the complete vault REST API, while
+still benefiting from token control, JSON parsing, and other HTTP client
+niceties.
 
 ## Installation and Usage
 
 ### Installation
 
-Ensure that any adapter dependencies have been included as part of your application's
-dependencies:
+Ensure that any adapter dependencies have been included as part of your
+application's dependencies:
 
 ```elixir
 def deps do
@@ -128,7 +138,8 @@ vault =
 {:ok, %{"version" => 1 }} = Vault.write(vault, "secret/path/to/creds", %{secret: "secrets!"})
 ```
 
-You can configure the vault client up front, or change configuration on the fly.
+You can configure the vault client up front, or change configuration on the
+fly.
 
 ```elixir
   vault =
@@ -148,17 +159,18 @@ See the full `Vault` client for additional methods.
 
 ## Testing Locally
 
-When possible, tests run against a local vault instance. Otherwise, tests run against the Vault Spec, using bypass to test to confirm the success case, and follows vault patterns for failure.
+When possible, tests run against a local vault instance. Otherwise, tests run
+against the Vault Spec, using bypass to test to confirm the success case, and
+follows vault patterns for failure.
 
 1. Install the Vault Go CLI https://www.vaultproject.io/downloads.html
 
-1. In the current directory, set up a local dev server with `sh scripts/setup-local-vault`
+1. In the current directory, set up a local dev server with `sh
+   scripts/setup-local-vault`
 
-1. Vault (at this time) can't be run in the background without a docker instance. For now, set up the local secret engine paths with `sh scripts/setup-engines.sh`
-
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at [https://hexdocs.pm/libvault](https://hexdocs.pm/libvault).
+1. Vault (at this time) can't be run in the background without a docker
+   instance. For now, set up the local secret engine paths with `sh
+   scripts/setup-engines.sh`
 
 [mint]: https://github.com/ericmj/mint
 [hackney]: https://github.com/benoitc/hackney

--- a/lib/vault/auth/adapter.ex
+++ b/lib/vault/auth/adapter.ex
@@ -1,15 +1,15 @@
 defmodule Vault.Auth.Adapter do
   @moduledoc """
-  Adapter interface for authenticating with vault. 
+  Adapter interface for authenticating with vault.
 
   ## Writing your own adapter
   Auth adapters are pretty simple. You build a url, map the parameters, and grab
-  the response. Feel free to use the provided `Vault.HTTP` module to make http 
-  requests against your vault instance. 
+  the response. Feel free to use the provided `Vault.HTTP` module to make http
+  requests against your vault instance.
 
-  In most cases, you'll end up sending a POST to `auth/SOME_BACKEND/login`, 
-  and pass the parameters along as a body. Below, you'll find a starting template 
-  for your own adapter. If you're writing an official implementation, check the 
+  In most cases, you'll end up sending a POST to `auth/SOME_BACKEND/login`,
+  and pass the parameters along as a body. Below, you'll find a starting template
+  for your own adapter. If you're writing an official implementation, check the
   Docs link below for the spec.
 
   [Vault Auth Method Docs](https://www.vaultproject.io/api/auth/index.html)
@@ -47,7 +47,7 @@ defmodule Vault.Auth.Adapter do
       end
     end
 
-    def login(%Vault{http: http, host: host}, _params), 
+    def login(%Vault{http: http, host: host}, _params),
       do: {:error, ["Missing params! Username and password are required."]}
   end
 

--- a/lib/vault/auth/azure.ex
+++ b/lib/vault/auth/azure.ex
@@ -1,6 +1,6 @@
 defmodule Vault.Auth.Azure do
   @moduledoc """
-  Azure Auth Adapter. 
+  Azure Auth Adapter.
 
   [Vault Docs](https://www.vaultproject.io/api/auth/azure/index.html)
   """

--- a/lib/vault/auth/generic.ex
+++ b/lib/vault/auth/generic.ex
@@ -22,7 +22,7 @@ defmodule Vault.Auth.Generic do
   @behaviour Vault.Auth.Adapter
 
   @doc """
-  Authenticate with a custom auth method. Provide options for the request, and how 
+  Authenticate with a custom auth method. Provide options for the request, and how
   to parse the response.
 
   ## Examples
@@ -33,16 +33,16 @@ defmodule Vault.Auth.Generic do
   - `body`- any params needed to login. Defaults to `%{}`
 
   `response` defines parameters for parsing the response.
-  - `token_path` - a list of properties that describe the JSON path to a token. Defaults to `["auth", "client_token"]` 
+  - `token_path` - a list of properties that describe the JSON path to a token. Defaults to `["auth", "client_token"]`
   - `ttl_path` - a list of properties that describe the JSON path to the ttl, or lease duration. Defaults to ["auth", "lease_duration"]
 
 
   The following would provide a minimal adapter for the JWT backend:
   ```
-  {:ok, token, ttl} = Vault.Auth.Generic.login(vault, %{ 
+  {:ok, token, ttl} = Vault.Auth.Generic.login(vault, %{
     request: %{
-      path: "/jwt/login", 
-      body: %{role: "my-role", jwt: "my-jwt" }, 
+      path: "/jwt/login",
+      body: %{role: "my-role", jwt: "my-jwt" },
     }
   })
   ```
@@ -50,17 +50,17 @@ defmodule Vault.Auth.Generic do
   Here's the above example as part of the full Vault client flow. On success,
   it returns an authenticated vault client.
   ```
-  vault = 
+  vault =
     Vault.new([
       auth: Vault.Auth.Generic,
       http: Vault.HTTP.Tesla,
       engine: Vault.KVV2
     ])
 
-  {:ok, vault} = Vault.auth(vault, %{ 
+  {:ok, vault} = Vault.auth(vault, %{
     request: %{
-      path: "/jwt/login", 
-      body: %{role: "my-role", jwt: "my-jwt" }, 
+      path: "/jwt/login",
+      body: %{role: "my-role", jwt: "my-jwt" },
     }
   })
   ```
@@ -68,18 +68,18 @@ defmodule Vault.Auth.Generic do
   Here's a more explicit example, with every option configured.
   ```
 
-  vault = 
+  vault =
     Vault.new([
       auth: Vault.Auth.Generic,
       http: Vault.HTTP.Tesla,
       engine: Vault.KVV2
     ])
 
-  {:ok, vault} = Vault.auth(vault, %{ 
+  {:ok, vault} = Vault.auth(vault, %{
     request:
-      path: "/jwt/login", 
+      path: "/jwt/login",
       method: :post,
-      body: %{role: "my-role", jwt: "my-jwt" }, 
+      body: %{role: "my-role", jwt: "my-jwt" },
     response: %{
       token: ["auth", "client_token"],
       ttl: ["auth", "lease_duration"]

--- a/lib/vault/auth/google_cloud.ex
+++ b/lib/vault/auth/google_cloud.ex
@@ -1,6 +1,6 @@
 defmodule Vault.Auth.GoogleCloud do
   @moduledoc """
-  Google Cloud Auth Adapter. 
+  Google Cloud Auth Adapter.
 
   [Vault Docs](https://www.vaultproject.io/api/auth/gcp/index.html)
   """

--- a/lib/vault/auth/jwt.ex
+++ b/lib/vault/auth/jwt.ex
@@ -1,6 +1,6 @@
 defmodule Vault.Auth.JWT do
   @moduledoc """
-  JWT Auth Adapter. 
+  JWT Auth Adapter.
 
   [Vault Docs](https://www.vaultproject.io/api/auth/jwt/index.html)
   """
@@ -15,7 +15,7 @@ defmodule Vault.Auth.JWT do
   ```
   # Atom Map
   {:ok, token, ttl} = Vault.Auth.JWT.login(vault, %{role: "dev-role", jwt: "my-jwt"})
-    
+
   # String Map
   {:ok, token, ttl} = Vault.Auth.JWT.login(vault, %{"role" => "my-role", "jwt" => "my-jwt"})
 

--- a/lib/vault/auth/kubernetes.ex
+++ b/lib/vault/auth/kubernetes.ex
@@ -1,6 +1,6 @@
 defmodule Vault.Auth.Kubernetes do
   @moduledoc """
-  Kubernetes Auth Adapter. 
+  Kubernetes Auth Adapter.
 
   [Vault Docs](https://www.vaultproject.io/api/auth/kubernetes/index.html)
   """
@@ -15,7 +15,7 @@ defmodule Vault.Auth.Kubernetes do
   ```
   # Atom map
   {:ok, token, ttl} = Vault.Auth.Kubernetes.login(vault, %{role: "my-role", jwt: "my-jwt"})
-    
+
   # String Map
   {:ok, token, ttl} = Vault.Auth.Kubernetes.login(vault, %{"role" => "my-role", "jwt" => "my-jwt"})
 

--- a/lib/vault/auth/token.ex
+++ b/lib/vault/auth/token.ex
@@ -1,7 +1,7 @@
 defmodule Vault.Auth.Token do
   @moduledoc """
   Token Auth Adapter. Checks a provided token for validity, and saves if valid. Useful
-  for local dev, or writing a CLI that uses the `.vault-token` file in the home 
+  for local dev, or writing a CLI that uses the `.vault-token` file in the home
   directory.
 
   [Vault Docs](https://www.vaultproject.io/api/auth/token/index.html#lookup-a-token-self-)

--- a/lib/vault/engine/generic.ex
+++ b/lib/vault/engine/generic.ex
@@ -1,14 +1,14 @@
 defmodule Vault.Engine.Generic do
   @moduledoc """
-  A generic Vault.Engine adapter. Most of the vault secret engines don't use a 
+  A generic Vault.Engine adapter. Most of the vault secret engines don't use a
   wildly different API, and can be handled with a single adapter.
 
   ## Request Details
-  By default, `read` runs a GET request, `write` does a POST, `list` does a GET 
-  with an appended `?list=true`, and `delete` runs a DELETE. The options below 
+  By default, `read` runs a GET request, `write` does a POST, `list` does a GET
+  with an appended `?list=true`, and `delete` runs a DELETE. The options below
   should give you additional flexibility.
 
-  ### Request Options: 
+  ### Request Options:
   - :method - one of :get, :put, :post, :options, :patch, :head
   - :full_response - if `true`, returns the full response body on success, rather than just the `data` key. Defaults to `false`,
   - :query_params - query params for the request. Defaults to `%{}` (no params)
@@ -18,7 +18,7 @@ defmodule Vault.Engine.Generic do
 
   Create a generic vault client:
 
-    {:ok, vault } = 
+    {:ok, vault } =
       Vault.new(
         host: System.get_env("VAULT_ADDR"),
         auth: Vault.Auth.Token,
@@ -46,10 +46,10 @@ defmodule Vault.Engine.Generic do
       })
 
     # read a role, and return the full response
-    {:ok, %{ "data" => data } } = 
+    {:ok, %{ "data" => data } } =
       Vault.read(vault, "ssh-client-signer/roles/test", full_response: true)
 
-  Options: 
+  Options:
   - :method - one of :get, :put, :post, :options, :patch, :head
   - :full_response - if `true`, returns the full response body on success, rather than just the `data` key. Defaults to `false`,
   - :params - query params for the request. Defaults to `%{}` (no params)
@@ -65,8 +65,8 @@ defmodule Vault.Engine.Generic do
   @type errors :: list()
 
   @doc """
-  Gets a value from vault. Defaults to a GET request against the current path. 
-  See `optionx` details above for full configuration.
+  Gets a value from vault. Defaults to a GET request against the current path.
+  See `option` details above for full configuration.
   """
   @impl true
   def read(vault, path, options \\ []) do
@@ -75,7 +75,7 @@ defmodule Vault.Engine.Generic do
   end
 
   @doc """
-  Puts a value in vault. Defaults to a POST request against the provided path.  
+  Puts a value in vault. Defaults to a POST request against the provided path.
   See `options` details above for full configuration.
   """
   @impl true
@@ -85,17 +85,17 @@ defmodule Vault.Engine.Generic do
   end
 
   @doc """
-  Lists secrets at a path. Defaults to a GET request against the provided path, 
-  with a query param of ?list=true.  
+  Lists secrets at a path. Defaults to a GET request against the provided path,
+  with a query param of ?list=true.
 
   See `options` details above for full configuration.
 
   ## Examples
 
   ```
-  {:ok, %{ 
-      "keys"=> ["foo", "foo/"] 
-    } 
+  {:ok, %{
+      "keys"=> ["foo", "foo/"]
+    }
   } = Vault.Engine.Generic.list(vault, "path/to/list/", [full_response: true])
   ```
   With the full Response:

--- a/lib/vault/engine/kv/v2.ex
+++ b/lib/vault/engine/kv/v2.ex
@@ -15,7 +15,7 @@ defmodule Vault.Engine.KVV2 do
   @type options :: list()
 
   @doc """
-  Get a secret from vault. Optionally supply a version, otherwise gets latest 
+  Get a secret from vault. Optionally supply a version, otherwise gets latest
   value.
 
   ## Examples
@@ -28,7 +28,7 @@ defmodule Vault.Engine.KVV2 do
   ```
 
   Because of the nature of soft deletes,fetching soft-deleted secrets will return
-  an error. 
+  an error.
 
   ```
   {:error, ["Key not found"]} = Vault.Engine.KVV2.read(vault, "soft/deleted/secret", [version: 1])
@@ -54,14 +54,14 @@ defmodule Vault.Engine.KVV2 do
       "request_id" => "e289ff31-609f-44fa-7161-55c63fda3d43",
       "warnings" => nil,
       "wrap_info" => nil
-    } 
+    }
   } = Vault.Engine.KVV2.read(vault, "soft/deleted/secret", [version: 1, full_response: true])
 
   ```
 
   Options:
   - `version: integer` - the version you want to return.
-  - `full_response: boolean` - get the whole reponse back on success, not just the data field
+  - `full_response: boolean` - get the whole response back on success, not just the data field
   """
   @impl true
   @spec read(vault, path, options) :: {:ok, value} | {:error, errors}
@@ -85,7 +85,7 @@ defmodule Vault.Engine.KVV2 do
   end
 
   @doc """
-  Put a secret in vault, on a given path. 
+  Put a secret in vault, on a given path.
 
   ## Examples
 
@@ -94,7 +94,7 @@ defmodule Vault.Engine.KVV2 do
   {:ok, %{}} = Vault.Engine.Generic.write(vault, "path/to/write", %{ foo: "bar" })
   ```
 
-  Check and set  - see [Vault Docs](https://www.vaultproject.io/api/secret/kv/kv-v2.html#create-update-secret) 
+  Check and set  - see [Vault Docs](https://www.vaultproject.io/api/secret/kv/kv-v2.html#create-update-secret)
   for details
 
   ```
@@ -123,7 +123,7 @@ defmodule Vault.Engine.KVV2 do
 
   ### Options
   - `cas: integer` set a check-and-set value
-  - `full_response: boolean` - get the whole reponse back on success, not just the data field
+  - `full_response: boolean` - get the whole response back on success, not just the data field
   """
   @impl true
   @spec write(vault, path, value, options) :: {:ok, map()} | {:error, errors}
@@ -137,15 +137,15 @@ defmodule Vault.Engine.KVV2 do
   end
 
   @doc """
-  This endpoint returns a list of key names at the specified location. Folders are 
+  This endpoint returns a list of key names at the specified location. Folders are
   suffixed with /. The input must be a folder; list on a file will not return a value.
 
   ## Examples
 
   ```
-  {:ok, %{ 
-      "keys"=> ["foo", "foo/"] 
-    } 
+  {:ok, %{
+      "keys"=> ["foo", "foo/"]
+    }
   } = Vault.Engine.KVV2.List(vault, "path/to/list/", [full_response: true])
   ```
   With the full Response:
@@ -166,7 +166,7 @@ defmodule Vault.Engine.KVV2 do
   end
 
   @doc """
-  Soft or Hard Delete a versioned secret. Requires a list of versions to be removed. This request 
+  Soft or Hard Delete a versioned secret. Requires a list of versions to be removed. This request
   produces an empty body, so an empty map is returned.
 
   ## Examples
@@ -181,7 +181,7 @@ defmodule Vault.Engine.KVV2 do
         "destroyed" => false,
         "version" => 5
       }
-    } 
+    }
   } = Vault.Engine.KVV2.Delete(vault, "path/to/delete", versions: [5], full_response: true)
   ```
 
@@ -194,7 +194,7 @@ defmodule Vault.Engine.KVV2 do
         "destroyed" => true,
         "version" => 5
       }
-    } 
+    }
   } = Vault.Engine.KVV2.Delete(vault, "path/to/delete", versions: [5], destroy: true, full_response: true)
 
   """

--- a/lib/vault/http/adapter.ex
+++ b/lib/vault/http/adapter.ex
@@ -2,7 +2,7 @@ defmodule Vault.HTTP.Adapter do
   @moduledoc """
   Adapter interface for making Vault HTTP.
 
-  `Vault` comes with a basic Tesla Adapter, providing support for `hackney`, 
+  `Vault` comes with a basic Tesla Adapter, providing support for `hackney`,
   `httpc`, and `ibrowse`
   """
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,10 +1,13 @@
 defmodule Vault.MixProject do
   use Mix.Project
 
+  @source_url "https://github.com/matthewoden/libvault"
+  @version "0.2.3"
+
   def project do
     [
       app: :libvault,
-      version: "0.2.2",
+      version: @version,
       elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env()),
       description: description(),
@@ -15,18 +18,15 @@ defmodule Vault.MixProject do
     ]
   end
 
-  # Run "mix help compile.app" to learn about applications.
   def application do
     [
       extra_applications: [:logger]
     ]
   end
 
-  # Specifies which paths to compile per environment.
   defp elixirc_paths(:test), do: ["lib", "test/support"]
   defp elixirc_paths(_), do: ["lib"]
 
-  # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
       # http clients
@@ -39,6 +39,7 @@ defmodule Vault.MixProject do
       # json parsers
       {:jason, ">= 1.0.0", only: [:dev, :test]},
       {:poison, "~> 3.0", only: [:dev, :test]},
+
       # testing
       {:bypass, "~> 1.0", only: :test},
       {:plug_cowboy, "~> 1.0", only: :test},
@@ -50,6 +51,9 @@ defmodule Vault.MixProject do
 
   defp docs do
     [
+      main: "readme",
+      source_ref: "v#{@version}",
+      source_url: @source_url,
       formatter_opts: [gfm: true],
       extras: ["README.md"]
     ]
@@ -68,7 +72,7 @@ defmodule Vault.MixProject do
       files: ["lib", "mix.exs", "README.md", "LICENSE.md"],
       maintainers: ["Matthew Oden Potter"],
       licenses: ["MIT"],
-      links: %{GitHub: "https://github.com/matthewoden/libvault"}
+      links: %{GitHub: @source_url}
     ]
   end
 end


### PR DESCRIPTION
List of changes:

- Set readme as default page in HTML doc
- Fix typos
- Fix trailing spaces
- Remove duplicate contents between README and module doc
- Set HTML link to the top of the page
- Badges and more badges!
- Add link to Vault
- Fix invalid released module version