### PR TITLE
Allow upgraded castore

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -32,7 +32,7 @@ defmodule Vault.MixProject do
       # http clients
       {:ibrowse, "~> 4.4.0", optional: true},
       {:hackney, "~> 1.6", optional: true},
-      {:castore, "~> 0.1", optional: true},
+      {:castore, "~> 0.1.0 or ~> 1.0", optional: true},
       {:mint, "~> 1.0", optional: true},
       {:tesla, "~> 1.3", optional: true},
 


### PR DESCRIPTION
This is holding back castore to 0.1.22 in our app, I thought others might have the same problem. This solution is used by a few other libraries like mint, tesla, and rustler_precompiled while phoenix just sets it to `>= 0.0.0`